### PR TITLE
Add focus style for form inputs

### DIFF
--- a/app/_less/components/forms.less
+++ b/app/_less/components/forms.less
@@ -37,6 +37,14 @@ textarea {
   .text-form-elements();
 }
 
+[type="text"]:focus,
+[type="email"]:focus,
+textarea:focus {
+  outline: none;
+  border-color: #000;
+  box-shadow: 0 0 0 3px rgb(21, 97, 248);
+}
+
 [type="submit"] {
   .text-form-elements();
   background-color: @blue-400;

--- a/app/_less/components/forms.less
+++ b/app/_less/components/forms.less
@@ -20,7 +20,7 @@ form {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  overflow: hidden;
+  // overflow: hidden;
   position: relative;
   transition: height 400ms;
   //margin: 1rem auto 2rem;


### PR DESCRIPTION
Removes `overflow: hidden` from `form` elements and adds customized styling to form `input`s
